### PR TITLE
Updated action versions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.6
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.ACTION_UPDATER }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v4.1.6
     - uses: actions/setup-node@v4.0.2
       with:
         node-version: 16


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.6](https://github.com/actions/checkout/releases/tag/v4.1.6)** on 2024-05-16T18:11:28Z
